### PR TITLE
Add "typeid" in the exclusion list in CheckCStyleCast"

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -5357,7 +5357,7 @@ def CheckCStyleCast(filename, clean_lines, linenum, cast_type, pattern, error):
 
   # Exclude lines with keywords that tend to look like casts
   context = line[0:match.start(1) - 1]
-  if Match(r'.*\b(?:sizeof|alignof|alignas|[_A-Z][_A-Z0-9]*)\s*$', context):
+  if Match(r'.*\b(?:sizeof|typeid|alignof|alignas|[_A-Z][_A-Z0-9]*)\s*$', context):
     return False
 
   # Try expanding current context to see if we one level of


### PR DESCRIPTION
Using C++ `typeid` function (e.g., `typeid(int) == typeid(bool)`) generates the following error.

> generates an error "All parameters should be named in a function  [readability/function] [3]"

Please add `typeid` in the exclusion list in `CheckCStyleCast`.
